### PR TITLE
Restore py38 support

### DIFF
--- a/recipe/0002-Fix-py38-support.patch
+++ b/recipe/0002-Fix-py38-support.patch
@@ -1,0 +1,11 @@
+--- ./crossenv/scripts/sysconfig-patch.py.tmpl.orig	2021-12-27 12:22:09.000000000 -0800
++++ ./crossenv/scripts/sysconfig-patch.py.tmpl	2021-12-27 12:22:14.000000000 -0800
+@@ -11,7 +11,7 @@
+ def get_makefile_filename():
+     return {{repr(self.host_makefile)}}
+ 
+-def _get_sysconfigdata_name():
++def _get_sysconfigdata_name(*args):
+     return {{repr(sysconfig_name)}}
+ 
+ def get_platform():

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 642c16105a79edb70840e04cf49fcdf241813e8953310e1d2d92e739dece3958
   patches:
     - 0001-Add-pypy37-support.patch
+    - 0002-Fix-py38-support.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/eups-feedstock/pull/25#issuecomment-1001727127 .  cc @isuruf 

We might need to mark build 0 as broken, at least on py=3.8?

I checked that this patch works with py38 and 39.

<!--
Please add any other relevant info below:
-->
