### PR TITLE
Fix pypy builds

### DIFF
--- a/recipe/0003-Provide-empty-lines-if-there-is-no-Makefile.patch
+++ b/recipe/0003-Provide-empty-lines-if-there-is-no-Makefile.patch
@@ -1,0 +1,25 @@
+From 65ad2066e88073b62a34d2bf55b9928187095bd0 Mon Sep 17 00:00:00 2001
+From: "Uwe L. Korn" <uwe.korn@quantco.com>
+Date: Wed, 29 Dec 2021 20:50:18 +0100
+Subject: [PATCH] Provide empty lines if there is no Makefile
+
+---
+ crossenv/__init__.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/crossenv/__init__.py b/crossenv/__init__.py
+index f52aaf1..7859347 100644
+--- a/crossenv/__init__.py
++++ b/crossenv/__init__.py
+@@ -334,6 +334,8 @@ class CrossEnvBuilder(venv.EnvBuilder):
+                     if host_platform:
+                         self.host_platform = host_platform
+                     break
++        else:
++            lines = []
+ 
+         if self.host_platform is None:
+             # It was probably natively compiled, but not necessarily for this
+-- 
+2.34.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
   patches:
     - 0001-Add-pypy37-support.patch
     - 0002-Fix-py38-support.patch
+    - 0003-Provide-empty-lines-if-there-is-no-Makefile.patch
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
The activation for pypy is currently failing with `ERROR: local variable 'lines' referenced before assignment`.

Also made an upstream PR: https://github.com/benfogle/crossenv/pull/85

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
